### PR TITLE
Make etcher-latest-version more robust

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@
 var semver = require('semver');
 var xml = require('xml2js');
 var BUCKET_URL = 'https://resin-production-downloads.s3.amazonaws.com';
-var NUMBER_OF_PACKAGES = 6;
+var PACKAGE_NAME = 'etcher';
+var NUMBER_OF_PACKAGES = 8;
 
 /**
  * @summary Get Etcher latest version
@@ -85,13 +86,17 @@ module.exports = function(request, callback) {
       var bucketEntries = result.ListBucketResult.Contents;
 
       return callback(null, bucketEntries.reduce(function(accumulator, entry) {
-        var version = entry.Key[0].split('/')[1];
-        accumulator[version] = accumulator[version] || 0;
-        accumulator[version] += 1;
+        var entryParts = entry.Key[0].split('/');
+        var name = entryParts[0];
+        var version = entryParts[1];
+        if (name === PACKAGE_NAME) {
+          accumulator[version] = accumulator[version] || 0;
+          accumulator[version] += 1;
 
-        if (accumulator[version] >= NUMBER_OF_PACKAGES &&
-            semver.gt(version, accumulator.latest)) {
-          accumulator.latest = version;
+          if (accumulator[version] >= NUMBER_OF_PACKAGES &&
+              semver.gt(version, accumulator.latest)) {
+            accumulator.latest = version;
+          }
         }
 
         return accumulator;

--- a/test.spec.js
+++ b/test.spec.js
@@ -51,91 +51,119 @@ describe('EtcherLatestVersion', function() {
       <MaxKeys>1000</MaxKeys>\
       <IsTruncated>false</IsTruncated>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-darwin-x64.dmg</Key>\
-        <LastModified>2016-03-10T17:34:21.000Z</LastModified>\
-        <ETag>"5a715255aa25686688bf1e23bc1d3fc6"</ETag>\
-        <Size>46109720</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-darwin-x64.dmg</Key>\
+        <LastModified>2016-11-28T16:12:28.000Z</LastModified>\
+        <ETag>"5818b791238e7a03c2128149cbcabfd6"</ETag>\
+        <Size>73532901</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-darwin-x64.zip</Key>\
-        <LastModified>2016-04-08T20:12:03.000Z</LastModified>\
-        <ETag>"cc1d6d9d53385e3edd099416fcd894c1"</ETag>\
-        <Size>47071474</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-darwin-x64.zip</Key>\
+        <LastModified>2016-11-28T16:52:26.000Z</LastModified>\
+        <ETag>"e9b4e7350e352298de293bb44aa72e9c"</ETag>\
+        <Size>154896510</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-linux-x64.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-linux-x64.zip</Key>\
+        <LastModified>2016-11-28T18:27:10.000Z</LastModified>\
+        <ETag>"40e2b620d2aecb87e44c8675f2028d03"</ETag>\
+        <Size>71186664</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-linux-x86.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-linux-x86.zip</Key>\
+        <LastModified>2016-11-28T17:56:56.000Z</LastModified>\
+        <ETag>"e585bd96708d79845015cc57d86a3f60"</ETag>\
+        <Size>72576097</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-win32-x64.exe</Key>\
-        <LastModified>2016-04-18T01:32:09.000Z</LastModified>\
-        <ETag>"c173895886f44d115c66e7206ce3dff8"</ETag>\
-        <Size>50585335</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x64.exe</Key>\
+        <LastModified>2016-11-28T20:01:43.000Z</LastModified>\
+        <ETag>"f6134fedb835af59db063810fb511ef0"</ETag>\
+        <Size>84717856</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-win32-x86.exe</Key>\
-        <LastModified>2016-04-18T01:32:09.000Z</LastModified>\
-        <ETag>"c173895886f44d115c66e7206ce3dff8"</ETag>\
-        <Size>50585335</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x64.zip</Key>\
+        <LastModified>2016-11-28T20:21:55.000Z</LastModified>\
+        <ETag>"8c6db54d2210355563519c67c1618664"</ETag>\
+        <Size>82056508</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-darwin-x64.dmg</Key>\
-        <LastModified>2016-03-10T17:34:21.000Z</LastModified>\
-        <ETag>"5a715255aa25686688bf1e23bc1d3fc6"</ETag>\
-        <Size>46109720</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x86.exe</Key>\
+        <LastModified>2016-11-28T20:39:43.000Z</LastModified>\
+        <ETag>"fdcc21ec9a7312b781c03b8d469e843d"</ETag>\
+        <Size>74151760</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-darwin-x64.zip</Key>\
-        <LastModified>2016-04-08T20:12:03.000Z</LastModified>\
-        <ETag>"cc1d6d9d53385e3edd099416fcd894c1"</ETag>\
-        <Size>47071474</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x86.zip</Key>\
+        <LastModified>2016-11-28T20:57:31.000Z</LastModified>\
+        <ETag>"992c2c021575d5909dbe77a759b67464"</ETag>\
+        <Size>71846504</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-linux-x64.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-darwin-x64.dmg</Key>\
+        <LastModified>2017-01-17T00:58:49.000Z</LastModified>\
+        <ETag>"81a1b5a330a230ca6d89db97b3399420"</ETag>\
+        <Size>58442097</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-linux-x86.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-darwin-x64.zip</Key>\
+        <LastModified>2017-01-17T01:18:56.000Z</LastModified>\
+        <ETag>"81b438a9f7b2d4c871cfbd5aedd96975"</ETag>\
+        <Size>139834277</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-win32-x64.exe</Key>\
-        <LastModified>2016-04-18T01:32:09.000Z</LastModified>\
-        <ETag>"c173895886f44d115c66e7206ce3dff8"</ETag>\
-        <Size>50585335</Size>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-linux-x64.zip</Key>\
+        <LastModified>2017-01-17T02:01:01.000Z</LastModified>\
+        <ETag>"35660b65233082a10c00828ea1e50c38"</ETag>\
+        <Size>55960697</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-win32-x86.exe</Key>\
-        <LastModified>2016-04-18T01:32:09.000Z</LastModified>\
-        <ETag>"c173895886f44d115c66e7206ce3dff8"</ETag>\
-        <Size>50585335</Size>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-linux-x86.zip</Key>\
+        <LastModified>2017-01-17T02:18:20.000Z</LastModified>\
+        <ETag>"1bafcc0d5d2c8d43bd2ce8948bb51a8b"</ETag>\
+        <Size>57331229</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x64.exe</Key>\
+        <LastModified>2017-01-17T05:48:02.000Z</LastModified>\
+        <ETag>"b0a6154ec79d17618632ac62eb30b44e"</ETag>\
+        <Size>84802632</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x64.zip</Key>\
+        <LastModified>2017-01-17T06:14:46.000Z</LastModified>\
+        <ETag>"f25c5dfa8378e608c25fafbe65e90162"</ETag>\
+        <Size>82235087</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x86.exe</Key>\
+        <LastModified>2017-01-17T06:42:58.000Z</LastModified>\
+        <ETag>"183b6eb648b0a78a1e99c9182f90194e"</ETag>\
+        <Size>74264232</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x86.zip</Key>\
+        <LastModified>2017-01-17T07:05:55.000Z</LastModified>\
+        <ETag>"d8d860013f038bed3f52534053b08382"</ETag>\
+        <Size>72042525</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
     </ListBucketResult>\
-  ', '1.0.0-beta.1');
+  ', '1.0.0-beta.18');
 
   test('given a version being uploaded at the moment', '\
     <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">\
@@ -145,83 +173,233 @@ describe('EtcherLatestVersion', function() {
       <MaxKeys>1000</MaxKeys>\
       <IsTruncated>false</IsTruncated>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-darwin-x64.dmg</Key>\
-        <LastModified>2016-03-10T17:34:21.000Z</LastModified>\
-        <ETag>"5a715255aa25686688bf1e23bc1d3fc6"</ETag>\
-        <Size>46109720</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-darwin-x64.dmg</Key>\
+        <LastModified>2016-11-28T16:12:28.000Z</LastModified>\
+        <ETag>"5818b791238e7a03c2128149cbcabfd6"</ETag>\
+        <Size>73532901</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-darwin-x64.zip</Key>\
-        <LastModified>2016-04-08T20:12:03.000Z</LastModified>\
-        <ETag>"cc1d6d9d53385e3edd099416fcd894c1"</ETag>\
-        <Size>47071474</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-darwin-x64.zip</Key>\
+        <LastModified>2016-11-28T16:52:26.000Z</LastModified>\
+        <ETag>"e9b4e7350e352298de293bb44aa72e9c"</ETag>\
+        <Size>154896510</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-linux-x64.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-linux-x64.zip</Key>\
+        <LastModified>2016-11-28T18:27:10.000Z</LastModified>\
+        <ETag>"40e2b620d2aecb87e44c8675f2028d03"</ETag>\
+        <Size>71186664</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-linux-x86.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-linux-x86.zip</Key>\
+        <LastModified>2016-11-28T17:56:56.000Z</LastModified>\
+        <ETag>"e585bd96708d79845015cc57d86a3f60"</ETag>\
+        <Size>72576097</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-win32-x64.exe</Key>\
-        <LastModified>2016-04-18T01:32:09.000Z</LastModified>\
-        <ETag>"c173895886f44d115c66e7206ce3dff8"</ETag>\
-        <Size>50585335</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x64.exe</Key>\
+        <LastModified>2016-11-28T20:01:43.000Z</LastModified>\
+        <ETag>"f6134fedb835af59db063810fb511ef0"</ETag>\
+        <Size>84717856</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.0/Etcher-win32-x86.exe</Key>\
-        <LastModified>2016-04-18T01:32:09.000Z</LastModified>\
-        <ETag>"c173895886f44d115c66e7206ce3dff8"</ETag>\
-        <Size>50585335</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x64.zip</Key>\
+        <LastModified>2016-11-28T20:21:55.000Z</LastModified>\
+        <ETag>"8c6db54d2210355563519c67c1618664"</ETag>\
+        <Size>82056508</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-darwin-x64.dmg</Key>\
-        <LastModified>2016-03-10T17:34:21.000Z</LastModified>\
-        <ETag>"5a715255aa25686688bf1e23bc1d3fc6"</ETag>\
-        <Size>46109720</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x86.exe</Key>\
+        <LastModified>2016-11-28T20:39:43.000Z</LastModified>\
+        <ETag>"fdcc21ec9a7312b781c03b8d469e843d"</ETag>\
+        <Size>74151760</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-darwin-x64.zip</Key>\
-        <LastModified>2016-04-08T20:12:03.000Z</LastModified>\
-        <ETag>"cc1d6d9d53385e3edd099416fcd894c1"</ETag>\
-        <Size>47071474</Size>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x86.zip</Key>\
+        <LastModified>2016-11-28T20:57:31.000Z</LastModified>\
+        <ETag>"992c2c021575d5909dbe77a759b67464"</ETag>\
+        <Size>71846504</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-linux-x64.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-darwin-x64.dmg</Key>\
+        <LastModified>2017-01-17T00:58:49.000Z</LastModified>\
+        <ETag>"81a1b5a330a230ca6d89db97b3399420"</ETag>\
+        <Size>58442097</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-linux-x86.AppImage</Key>\
-        <LastModified>2016-04-08T19:03:18.000Z</LastModified>\
-        <ETag>"5f1849f7781197ce2ee6129c16bcd498"</ETag>\
-        <Size>48650090</Size>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-darwin-x64.zip</Key>\
+        <LastModified>2017-01-17T01:18:56.000Z</LastModified>\
+        <ETag>"81b438a9f7b2d4c871cfbd5aedd96975"</ETag>\
+        <Size>139834277</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
       <Contents>\
-        <Key>etcher/1.0.0-beta.1/Etcher-win32-x64.exe</Key>\
-        <LastModified>2016-04-18T01:32:09.000Z</LastModified>\
-        <ETag>"c173895886f44d115c66e7206ce3dff8"</ETag>\
-        <Size>50585335</Size>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-linux-x64.zip</Key>\
+        <LastModified>2017-01-17T02:01:01.000Z</LastModified>\
+        <ETag>"35660b65233082a10c00828ea1e50c38"</ETag>\
+        <Size>55960697</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-linux-x86.zip</Key>\
+        <LastModified>2017-01-17T02:18:20.000Z</LastModified>\
+        <ETag>"1bafcc0d5d2c8d43bd2ce8948bb51a8b"</ETag>\
+        <Size>57331229</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x64.exe</Key>\
+        <LastModified>2017-01-17T05:48:02.000Z</LastModified>\
+        <ETag>"b0a6154ec79d17618632ac62eb30b44e"</ETag>\
+        <Size>84802632</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x64.zip</Key>\
+        <LastModified>2017-01-17T06:14:46.000Z</LastModified>\
+        <ETag>"f25c5dfa8378e608c25fafbe65e90162"</ETag>\
+        <Size>82235087</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x86.exe</Key>\
+        <LastModified>2017-01-17T06:42:58.000Z</LastModified>\
+        <ETag>"183b6eb648b0a78a1e99c9182f90194e"</ETag>\
+        <Size>74264232</Size>\
         <StorageClass>STANDARD</StorageClass>\
       </Contents>\
     </ListBucketResult>\
-  ', '1.0.0-beta.0');
+  ', '1.0.0-beta.17');
+
+  test('given higher version of different package', '\
+    <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">\
+      <Name>resin-production-downloads</Name>\
+      <Prefix/>\
+      <Marker/>\
+      <MaxKeys>1000</MaxKeys>\
+      <IsTruncated>false</IsTruncated>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-darwin-x64.dmg</Key>\
+        <LastModified>2016-11-28T16:12:28.000Z</LastModified>\
+        <ETag>"5818b791238e7a03c2128149cbcabfd6"</ETag>\
+        <Size>73532901</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-darwin-x64.zip</Key>\
+        <LastModified>2016-11-28T16:52:26.000Z</LastModified>\
+        <ETag>"e9b4e7350e352298de293bb44aa72e9c"</ETag>\
+        <Size>154896510</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-linux-x64.zip</Key>\
+        <LastModified>2016-11-28T18:27:10.000Z</LastModified>\
+        <ETag>"40e2b620d2aecb87e44c8675f2028d03"</ETag>\
+        <Size>71186664</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-linux-x86.zip</Key>\
+        <LastModified>2016-11-28T17:56:56.000Z</LastModified>\
+        <ETag>"e585bd96708d79845015cc57d86a3f60"</ETag>\
+        <Size>72576097</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x64.exe</Key>\
+        <LastModified>2016-11-28T20:01:43.000Z</LastModified>\
+        <ETag>"f6134fedb835af59db063810fb511ef0"</ETag>\
+        <Size>84717856</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x64.zip</Key>\
+        <LastModified>2016-11-28T20:21:55.000Z</LastModified>\
+        <ETag>"8c6db54d2210355563519c67c1618664"</ETag>\
+        <Size>82056508</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x86.exe</Key>\
+        <LastModified>2016-11-28T20:39:43.000Z</LastModified>\
+        <ETag>"fdcc21ec9a7312b781c03b8d469e843d"</ETag>\
+        <Size>74151760</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>etcher/1.0.0-beta.17/Etcher-1.0.0-beta.17-win32-x86.zip</Key>\
+        <LastModified>2016-11-28T20:57:31.000Z</LastModified>\
+        <ETag>"992c2c021575d5909dbe77a759b67464"</ETag>\
+        <Size>71846504</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-darwin-x64.dmg</Key>\
+        <LastModified>2017-01-17T00:58:49.000Z</LastModified>\
+        <ETag>"81a1b5a330a230ca6d89db97b3399420"</ETag>\
+        <Size>58442097</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-darwin-x64.zip</Key>\
+        <LastModified>2017-01-17T01:18:56.000Z</LastModified>\
+        <ETag>"81b438a9f7b2d4c871cfbd5aedd96975"</ETag>\
+        <Size>139834277</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-linux-x64.zip</Key>\
+        <LastModified>2017-01-17T02:01:01.000Z</LastModified>\
+        <ETag>"35660b65233082a10c00828ea1e50c38"</ETag>\
+        <Size>55960697</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-linux-x86.zip</Key>\
+        <LastModified>2017-01-17T02:18:20.000Z</LastModified>\
+        <ETag>"1bafcc0d5d2c8d43bd2ce8948bb51a8b"</ETag>\
+        <Size>57331229</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x64.exe</Key>\
+        <LastModified>2017-01-17T05:48:02.000Z</LastModified>\
+        <ETag>"b0a6154ec79d17618632ac62eb30b44e"</ETag>\
+        <Size>84802632</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x64.zip</Key>\
+        <LastModified>2017-01-17T06:14:46.000Z</LastModified>\
+        <ETag>"f25c5dfa8378e608c25fafbe65e90162"</ETag>\
+        <Size>82235087</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x86.exe</Key>\
+        <LastModified>2017-01-17T06:42:58.000Z</LastModified>\
+        <ETag>"183b6eb648b0a78a1e99c9182f90194e"</ETag>\
+        <Size>74264232</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+      <Contents>\
+        <Key>notEtcher/1.0.0-beta.18/Etcher-1.0.0-beta.18-win32-x86.zip</Key>\
+        <LastModified>2017-01-17T07:05:55.000Z</LastModified>\
+        <ETag>"d8d860013f038bed3f52534053b08382"</ETag>\
+        <Size>72042525</Size>\
+        <StorageClass>STANDARD</StorageClass>\
+      </Contents>\
+    </ListBucketResult>\
+  ', '1.0.0-beta.17');
 
 });


### PR DESCRIPTION
 * Etcher now uploads 8 packages at a time to S3, not 6
 * https://resin-production-downloads.s3.amazonaws.com no longer hosts *just* Etcher packages

Change-type: patch